### PR TITLE
Persist Drizzle with durable object

### DIFF
--- a/load-context.ts
+++ b/load-context.ts
@@ -7,9 +7,10 @@ declare global {
 	interface CloudflareEnvironment extends Env {
 		ADMIN_USERNAME: string;
 		ADMIN_PASSWORD: string;
-		ASSETS_BUCKET: R2Bucket;
-		PUBLIC_R2_URL: string;
-	}
+                ASSETS_BUCKET: R2Bucket;
+                PUBLIC_R2_URL: string;
+                DRIZZLE_DO: DurableObjectNamespace;
+        }
 }
 declare module "react-router" {
 	export interface AppLoadContext {

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -10,9 +10,10 @@ declare namespace Cloudflare {
 		JWT_SECRET: string;
 		PUBLIC_R2_URL: string;
 		CLOUDFLARE_D1_TOKEN: string;
-		ASSETS_BUCKET: R2Bucket;
-		DB: D1Database;
-	}
+                ASSETS_BUCKET: R2Bucket;
+                DB: D1Database;
+                DRIZZLE_DO: DurableObjectNamespace;
+        }
 }
 interface Env extends Cloudflare.Env {}
 

--- a/workers/app.ts
+++ b/workers/app.ts
@@ -1,18 +1,14 @@
-import type { ExecutionContext } from "@cloudflare/workers-types";
-import { type DrizzleD1Database, drizzle } from "drizzle-orm/d1";
-import { DefaultLogger } from "drizzle-orm/logger";
 import { createRequestHandler } from "react-router";
-import * as schema from "../database/schema";
 const serverBuildModuleResolver = () => {
-	return import("virtual:react-router/server-build");
+        return import("virtual:react-router/server-build");
 };
 const requestHandler = createRequestHandler(
-	serverBuildModuleResolver,
-	import.meta.env.MODE,
+        serverBuildModuleResolver,
+        import.meta.env.MODE,
 );
 export default {
-	async fetch(request, env, ctx) {
-		console.log("WORKER INVOKED", new Date().toISOString(), request.url);
+        async fetch(request, env, ctx) {
+                console.log("WORKER INVOKED", new Date().toISOString(), request.url);
 		const url = new URL(request.url);
 		if (url.pathname.startsWith("/assets/")) {
 			const key = url.pathname.slice("/assets/".length);
@@ -51,16 +47,8 @@ export default {
 				return new Response("Error fetching asset", { status: 500 });
 			}
 		}
-		const db = drizzle(env.DB, {
-			schema,
-			// Enable logger only in development mode
-			logger:
-				import.meta.env.MODE === "development" ? new DefaultLogger() : false,
-		});
-		const loadContext = {
-			cloudflare: { env, ctx: ctx as Omit<ExecutionContext, "props"> },
-			db,
-		};
-		return requestHandler(request, loadContext);
-	},
+                const id = env.DRIZZLE_DO.idFromName("db-instance");
+                const stub = env.DRIZZLE_DO.get(id);
+                return stub.fetch(request);
+        },
 } satisfies ExportedHandler<Env>;

--- a/workers/drizzle-durable.ts
+++ b/workers/drizzle-durable.ts
@@ -1,0 +1,26 @@
+import { type DrizzleD1Database, drizzle } from "drizzle-orm/d1";
+import { DefaultLogger } from "drizzle-orm/logger";
+import { createRequestHandler } from "react-router";
+import type { DurableObjectState, ExecutionContext } from "@cloudflare/workers-types";
+import * as schema from "../database/schema";
+
+const serverBuildModuleResolver = () => import("virtual:react-router/server-build");
+const requestHandler = createRequestHandler(serverBuildModuleResolver, import.meta.env.MODE);
+
+export class DrizzleDurable implements DurableObject {
+  private db: DrizzleD1Database<typeof schema>;
+  constructor(private state: DurableObjectState, private env: Env) {
+    this.db = drizzle(env.DB, {
+      schema,
+      logger: import.meta.env.MODE === "development" ? new DefaultLogger() : false,
+    });
+  }
+
+  async fetch(request: Request) {
+    const loadContext = {
+      cloudflare: { env: this.env, ctx: {} as Omit<ExecutionContext, "props"> },
+      db: this.db,
+    };
+    return requestHandler(request, loadContext);
+  }
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,9 +8,14 @@
 	"assets": {
 		"directory": "./build/client/"
 	},
-	"workers_dev": true,
-	"vars": {
-		"CLOUDFLARE_ACCOUNT_ID": "427aa00a5888cad78805c7128db1f817",
+        "workers_dev": true,
+        "durable_objects": {
+                "bindings": [
+                        { "name": "DRIZZLE_DO", "class_name": "DrizzleDurable" }
+                ]
+        },
+        "vars": {
+                "CLOUDFLARE_ACCOUNT_ID": "427aa00a5888cad78805c7128db1f817",
 		"CLOUDFLARE_DATABASE_ID": "89bb8c60-84fb-4f13-9320-e5cf623f4963",
 		"ADMIN_USERNAME": "admin",
 		"ADMIN_PASSWORD": "Stanley212$",
@@ -51,17 +56,22 @@
 				"JWT_SECRET": "super_secret_squidward_tentacles",
 				"PUBLIC_R2_URL": "https://427aa00a5888cad78805c7128db1f817.r2.cloudflarestorage.com/starter-assets/"
 			},
-			"r2_buckets": [
-				{
-					"binding": "ASSETS_BUCKET",
-					"bucket_name": "starter-assets",
-					"preview_bucket_name": "starter-assets-dev"
-				}
-			],
-			"d1_databases": [
-				{
-					"binding": "DB",
-					"database_name": "starter-content-db",
+                       "r2_buckets": [
+                               {
+                                       "binding": "ASSETS_BUCKET",
+                                       "bucket_name": "starter-assets",
+                                       "preview_bucket_name": "starter-assets-dev"
+                               }
+                       ],
+                        "durable_objects": {
+                                "bindings": [
+                                        { "name": "DRIZZLE_DO", "class_name": "DrizzleDurable" }
+                                ]
+                        },
+                       "d1_databases": [
+                               {
+                                       "binding": "DB",
+                                       "database_name": "starter-content-db",
 					"database_id": "89bb8c60-84fb-4f13-9320-e5cf623f4963",
 					"migrations_dir": "./migrations"
 				}


### PR DESCRIPTION
## Summary
- create a new `DrizzleDurable` object to keep Drizzle instance alive
- forward non-asset requests to the durable object
- add durable object bindings to environment types and wrangler config

## Testing
- `bun run format`