### PR TITLE
Extend Durable Object usage

### DIFF
--- a/app/routes/admin/actions/seed-content.tsx
+++ b/app/routes/admin/actions/seed-content.tsx
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/seed-content";
 import { data } from "react-router";
 import { getAllContent, updateContent } from "~/routes/common/db";
-import { getSessionCookie, verify } from "~/routes/common/utils/auth";
+import { checkSession } from "~/routes/common/utils/auth";
 
 const DEBUG = process.env.NODE_ENV !== "production";
 const DEFAULT_CONTENT = {
@@ -11,11 +11,10 @@ const DEFAULT_CONTENT = {
 } as const;
 
 export async function action({ request, context, params }: Route.ActionArgs) {
-	const token = getSessionCookie(request);
-	const secret = context.cloudflare?.env?.JWT_SECRET;
-	if (!token || !secret || !(await verify(token, secret))) {
-		return data({ success: false, error: "Unauthorized" }, { status: 401 });
-	}
+        const env = context.cloudflare?.env;
+        if (!env || !(await checkSession(request, env))) {
+                return data({ success: false, error: "Unauthorized" }, { status: 401 });
+        }
 	if (request.method !== "POST") {
 		return data({ error: "Invalid method. Please use POST." }, { status: 405 });
 	}

--- a/app/routes/admin/views/_layout.tsx
+++ b/app/routes/admin/views/_layout.tsx
@@ -13,7 +13,7 @@ import {
 	useLocation,
 	useNavigation,
 } from "react-router";
-import { getSessionCookie, verify } from "~/routes/common/utils/auth";
+import { checkSession } from "~/routes/common/utils/auth";
 import adminThemeStylesheet from "../../../admin-theme.css?url";
 import { AdminErrorBoundary } from "../components/AdminErrorBoundary";
 import { SidebarLayout } from "../components/ui/sidebar-layout";
@@ -29,20 +29,8 @@ export const loader = async ({ request, context }: Route.LoaderArgs) => {
 	const url = new URL(request.url);
 	const isLoginRoute = url.pathname === "/admin/login";
 	const isLogoutRoute = url.pathname === "/admin/logout";
-	const sessionValue = getSessionCookie(request);
-	const jwtSecret = context.cloudflare?.env?.JWT_SECRET;
-
-	const isAuthenticated = async () => {
-		if (!sessionValue || !jwtSecret) return false;
-		try {
-			return await verify(sessionValue, jwtSecret);
-		} catch (e) {
-			console.error("Token verification failed:", e);
-			return false;
-		}
-	};
-
-	const loggedIn = await isAuthenticated();
+        const env = context.cloudflare?.env;
+        const loggedIn = env ? await checkSession(request, env) : false;
 	if (!loggedIn && !isLoginRoute && !isLogoutRoute) {
 		return redirect("/admin/login");
 	}

--- a/app/routes/admin/views/index.tsx
+++ b/app/routes/admin/views/index.tsx
@@ -3,7 +3,7 @@ import { useSearchParams, useActionData, useNavigation } from "react-router";
 import { redirect } from "react-router";
 import { assert } from "~/routes/common/utils/assert";
 import { getAllContent, updateContent } from "~/routes/common/db";
-import { getSessionCookie, verify } from "~/routes/common/utils/auth";
+import { checkSession } from "~/routes/common/utils/auth";
 import AdminDashboard from "../components/AdminDashboard";
 import { ButtonLED } from "../components/ui/button";
 import { ValiError } from "valibot";
@@ -14,12 +14,10 @@ import type { Route } from "./+types";
 const DEBUG = process.env.NODE_ENV !== "production";
 
 export async function loader({ request, context }: Route.LoaderArgs) {
-	const token = getSessionCookie(request);
-	const secret = context.cloudflare?.env?.JWT_SECRET;
-
-	if (!token || !secret || !(await verify(token, secret))) {
-		throw redirect("/admin/login");
-	}
+        const env = context.cloudflare?.env;
+        if (!env || !(await checkSession(request, env))) {
+                throw redirect("/admin/login");
+        }
 
 	try {
 		const content = await getAllContent(context.db);
@@ -86,12 +84,10 @@ async function handleReorderSections(
 }
 
 export async function action({ request, context }: Route.ActionArgs) {
-	const token = getSessionCookie(request);
-	const secret = context.cloudflare?.env?.JWT_SECRET;
-
-	if (!token || !secret || !(await verify(token, secret))) {
-		return redirect("/admin/login");
-	}
+        const env = context.cloudflare?.env;
+        if (!env || !(await checkSession(request, env))) {
+                return redirect("/admin/login");
+        }
 
 	if (request.method !== "POST") {
 		return { success: false, error: "Method not allowed" };

--- a/app/routes/admin/views/logout.tsx
+++ b/app/routes/admin/views/logout.tsx
@@ -1,24 +1,28 @@
 import type { Route } from "./+types/logout";
 import { redirect } from "react-router";
-import { COOKIE_NAME } from "~/routes/common/utils/auth";
+import { COOKIE_NAME, getSessionCookie, verify } from "~/routes/common/utils/auth";
 
-async function handleLogout(): Promise<Response> {
-	const response = redirect("/admin/login");
-	response.headers.set(
-		"Set-Cookie",
-		`${COOKIE_NAME}=; Path=/; HttpOnly; Secure; SameSite=Strict; Max-Age=0`,
-	);
-	return response;
+async function handleLogout(request: Request, env: CloudflareEnvironment): Promise<Response> {
+        const sessionValue = getSessionCookie(request);
+        if (sessionValue) {
+                const sessionId = await verify(sessionValue, env.JWT_SECRET);
+                if (sessionId) {
+                        const stub = env.SESSION_DO.get(env.SESSION_DO.idFromName(sessionId));
+                        await stub.fetch(`https://session/${sessionId}`, { method: "DELETE" });
+                }
+        }
+        const response = redirect("/admin/login");
+        response.headers.set(
+                "Set-Cookie",
+                `${COOKIE_NAME}=; Path=/; HttpOnly; Secure; SameSite=Strict; Max-Age=0`,
+        );
+        return response;
 }
 
-export const loader = async ({
-	request,
-	context,
-	params,
-}: Route.LoaderArgs) => {
-	return handleLogout();
+export const loader = async ({ request, context }: Route.LoaderArgs) => {
+        return handleLogout(request, context.cloudflare.env);
 };
 
-export async function action({ request, context, params }: Route.ActionArgs) {
-	return handleLogout();
+export async function action({ request, context }: Route.ActionArgs) {
+        return handleLogout(request, context.cloudflare.env);
 }

--- a/load-context.ts
+++ b/load-context.ts
@@ -10,6 +10,7 @@ declare global {
                 ASSETS_BUCKET: R2Bucket;
                 PUBLIC_R2_URL: string;
                 DRIZZLE_DO: DurableObjectNamespace;
+                SESSION_DO: DurableObjectNamespace;
         }
 }
 declare module "react-router" {

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -13,6 +13,7 @@ declare namespace Cloudflare {
                 ASSETS_BUCKET: R2Bucket;
                 DB: D1Database;
                 DRIZZLE_DO: DurableObjectNamespace;
+                SESSION_DO: DurableObjectNamespace;
         }
 }
 interface Env extends Cloudflare.Env {}

--- a/workers/session-durable.ts
+++ b/workers/session-durable.ts
@@ -1,0 +1,38 @@
+import type { DurableObjectState } from "@cloudflare/workers-types";
+
+interface SessionRecord {
+  username: string;
+  createdAt: number;
+}
+
+const SESSION_TTL = 60 * 60 * 2; // 2 hours
+
+export class SessionDurable implements DurableObject {
+  constructor(private state: DurableObjectState, private env: Env) {}
+
+  async fetch(request: Request): Promise<Response> {
+    const id = new URL(request.url).pathname.slice(1);
+    if (!id) return new Response("Bad Request", { status: 400 });
+    switch (request.method) {
+      case "PUT": {
+        const data: SessionRecord = await request.json();
+        await this.state.storage.put(id, data, { expirationTtl: SESSION_TTL });
+        return new Response("OK");
+      }
+      case "GET": {
+        const data = await this.state.storage.get<SessionRecord>(id);
+        if (!data) return new Response("Not Found", { status: 404 });
+        return new Response(JSON.stringify(data), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      case "DELETE": {
+        await this.state.storage.delete(id);
+        return new Response("OK");
+      }
+      default:
+        return new Response("Method Not Allowed", { status: 405 });
+    }
+  }
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -11,7 +11,8 @@
         "workers_dev": true,
         "durable_objects": {
                 "bindings": [
-                        { "name": "DRIZZLE_DO", "class_name": "DrizzleDurable" }
+                        { "name": "DRIZZLE_DO", "class_name": "DrizzleDurable" },
+                        { "name": "SESSION_DO", "class_name": "SessionDurable" }
                 ]
         },
         "vars": {
@@ -65,7 +66,8 @@
                        ],
                         "durable_objects": {
                                 "bindings": [
-                                        { "name": "DRIZZLE_DO", "class_name": "DrizzleDurable" }
+                                        { "name": "DRIZZLE_DO", "class_name": "DrizzleDurable" },
+                                        { "name": "SESSION_DO", "class_name": "SessionDurable" }
                                 ]
                         },
                        "d1_databases": [


### PR DESCRIPTION
## Summary
- introduce `SessionDurable` for storing admin sessions
- register the new DO in `wrangler.jsonc`
- expose the new binding in env types and load-context
- add DO-backed session checks throughout admin routes
- persist and delete session data on login and logout

## Testing
- `bun run format`
- `bun test` *(fails: Expected ">" but found "router")*