### PR TITLE
Add Cloudflare usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ This template comes with [Tailwind CSS](https://tailwindcss.com/) already config
 - `public/` - Static files served without processing.
 - `scripts/` - Utility scripts like database seeds.
 - `docs/` - Additional project documentation.
+- See [`docs/cloudflare.md`](docs/cloudflare.md) for details on Workers, Durable Objects, D1, and R2.
 
 ## Next Steps
 

--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -1,0 +1,52 @@
+# Cloudflare Features Overview
+
+This project demonstrates how to combine several Cloudflare services together in a single Workers application. The key pieces are Workers, Durable Objects, D1, and R2.
+
+## Workers
+
+The Worker entry point lives in `workers/app.ts`. It serves static files from an R2 bucket and routes all other requests through the `DrizzleDurable` Durable Object. Wrangler is used for local development and deployment.
+
+To start the Worker locally:
+
+```bash
+bun run dev
+```
+
+### Deployment
+
+Use Wrangler to deploy either a preview version or directly to production:
+
+```bash
+bun wrangler deploy          # Deploy to the default environment
+bun wrangler versions upload # Upload a preview version
+bun wrangler versions deploy # Promote a version to production
+```
+
+## Durable Objects
+
+Durable Objects provide stateful logic. This template includes two examples:
+
+- `SessionDurable` in `workers/session-durable.ts` – a basic key/value store for session data.
+- `DrizzleDurable` in `workers/drizzle-durable.ts` – handles application requests and exposes the D1 database via Drizzle ORM.
+
+Both objects are registered in `wrangler.jsonc` so they are created automatically when you deploy.
+
+## D1 Database
+
+D1 is Cloudflare's managed SQLite service. Database schema and seed data live in the `database/` and `seeds/` folders. The sample `seed-database.sh` script can populate a local or remote D1 instance.
+
+Common tasks:
+
+```bash
+bun run db:generate   # Generate types and migrations
+bun run db:migrate    # Apply migrations locally
+bun run db:migrate-production # Apply migrations to production
+```
+
+## R2 Object Storage
+
+Static assets are stored in an R2 bucket. The Worker fetches files from the bucket when requests begin with `/assets/`. Set the `PUBLIC_R2_URL` secret for your account so that public asset links resolve correctly once deployed.
+
+---
+
+Check `wrangler.jsonc` for all bindings and environment variables. Feel free to customise these settings for your own project.

--- a/scripts/remote-seed.js
+++ b/scripts/remote-seed.js
@@ -45,7 +45,7 @@ const d1Stub = {
 
 // Log seed data instructions
 console.log('⭐ To seed the remote database, copy and run the SQL statements from seeds/initial-data.sql manually using:');
-console.log('bunx wrangler d1 execute lush-content-db --remote --file=./seeds/initial-data.sql');
+console.log('bunx wrangler d1 execute <your-d1-name> --remote --file=./seeds/initial-data.sql');
 console.log('\\n');
 
 // Call the seedDatabase to display the content that would be inserted
@@ -60,9 +60,9 @@ seedDatabase(d1Stub).catch(console.error);
 	console.log("✅ Seed simulation completed.");
 	console.log("");
 	console.log("To run the actual seed on the remote database, use:");
-	console.log(
-		"bunx wrangler d1 execute lush-content-db --remote --file=./seeds/initial-data.sql",
-	);
+        console.log(
+                "bunx wrangler d1 execute <your-d1-name> --remote --file=./seeds/initial-data.sql",
+        );
 } catch (error) {
 	console.error("Error:", error);
 	process.exit(1);


### PR DESCRIPTION
## Summary
- document how Cloudflare services fit together
- link the docs from README
- remove project branding from `remote-seed.js`

## Testing
- `bun run format` *(fails: No such file or directory errors)*