### PR TITLE
Refactor admin loaders to use service functions

### DIFF
--- a/app/routes/admin/services.ts
+++ b/app/routes/admin/services.ts
@@ -1,0 +1,29 @@
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import type { AppLoadContext } from "react-router";
+import { getAllContent } from "~/routes/common/db";
+import { listStoredImages } from "~/utils/upload.server";
+import type * as schema from "../../database/schema";
+
+export async function fetchAdminContent(
+	db: DrizzleD1Database<typeof schema>,
+): Promise<Record<string, string>> {
+	try {
+		return await getAllContent(db);
+	} catch (error) {
+		throw new Error(
+			"fetchAdminContent failed: " +
+				(error instanceof Error ? error.message : String(error)),
+		);
+	}
+}
+
+export async function fetchStoredImages(context: AppLoadContext) {
+	try {
+		return await listStoredImages(context);
+	} catch (error) {
+		throw new Error(
+			"fetchStoredImages failed: " +
+				(error instanceof Error ? error.message : String(error)),
+		);
+	}
+}

--- a/app/routes/admin/views/index.tsx
+++ b/app/routes/admin/views/index.tsx
@@ -1,26 +1,27 @@
 import React, { useEffect } from "react";
-import { useSearchParams, useActionData, useNavigation } from "react-router";
+import { useActionData, useNavigation, useSearchParams } from "react-router";
 import { redirect } from "react-router";
+import { Toaster, toast } from "sonner";
+import { ValiError } from "valibot";
+import { updateContent } from "~/routes/common/db";
 import { assert } from "~/routes/common/utils/assert";
-import { getAllContent, updateContent } from "~/routes/common/db";
 import { checkSession } from "~/routes/common/utils/auth";
+import { validateContentInsert } from "../../../../database/valibot-validation.js";
 import AdminDashboard from "../components/AdminDashboard";
 import { ButtonLED } from "../components/ui/button";
-import { ValiError } from "valibot";
-import { validateContentInsert } from "../../../../database/valibot-validation.js";
-import { toast, Toaster } from "sonner";
+import { fetchAdminContent } from "../services";
 import type { Route } from "./+types";
 
 const DEBUG = process.env.NODE_ENV !== "production";
 
 export async function loader({ request, context }: Route.LoaderArgs) {
-        const env = context.cloudflare?.env;
-        if (!env || !(await checkSession(request, env))) {
-                throw redirect("/admin/login");
-        }
+	const env = context.cloudflare?.env;
+	if (!env || !(await checkSession(request, env))) {
+		throw redirect("/admin/login");
+	}
 
 	try {
-		const content = await getAllContent(context.db);
+		const content = await fetchAdminContent(context.db);
 		if (DEBUG)
 			console.log("[ADMIN LOADER] Loaded content keys:", Object.keys(content));
 		return { content };
@@ -84,10 +85,10 @@ async function handleReorderSections(
 }
 
 export async function action({ request, context }: Route.ActionArgs) {
-        const env = context.cloudflare?.env;
-        if (!env || !(await checkSession(request, env))) {
-                return redirect("/admin/login");
-        }
+	const env = context.cloudflare?.env;
+	if (!env || !(await checkSession(request, env))) {
+		return redirect("/admin/login");
+	}
 
 	if (request.method !== "POST") {
 		return { success: false, error: "Method not allowed" };

--- a/app/routes/admin/views/projects/[projectId]/delete.tsx
+++ b/app/routes/admin/views/projects/[projectId]/delete.tsx
@@ -7,13 +7,14 @@ import {
 } from "~/routes/admin/components/ui/alert";
 import { Heading } from "~/routes/admin/components/ui/heading";
 import { FadeIn } from "~/routes/common/components/ui/FadeIn";
-import { deleteProject, getProjectById } from "~/routes/common/db";
+import { deleteProject } from "~/routes/common/db";
 import { FormCard } from "../../../components/ui/FormCard";
 import { PageHeader } from "../../../components/ui/PageHeader";
 import { Button } from "../../../components/ui/button";
 import { Label } from "../../../components/ui/fieldset";
 import { Input } from "../../../components/ui/input";
 import { Text } from "../../../components/ui/text";
+import { fetchAdminProject } from "../services";
 import type { Route } from "./+types/delete";
 
 export async function loader({ params, context, request }: Route.LoaderArgs) {
@@ -22,10 +23,7 @@ export async function loader({ params, context, request }: Route.LoaderArgs) {
 		throw new Response("Invalid Project ID", { status: 400 });
 	}
 	try {
-		const project = await getProjectById(context.db, projectId);
-		if (!project) {
-			throw new Response("Project not found", { status: 404 });
-		}
+		const project = await fetchAdminProject(context.db, projectId);
 		return { project };
 	} catch (error: unknown) {
 		console.error("Error fetching project:", error);

--- a/app/routes/admin/views/projects/[projectId]/edit.tsx
+++ b/app/routes/admin/views/projects/[projectId]/edit.tsx
@@ -2,13 +2,14 @@ import React from "react";
 import { Form, redirect } from "react-router";
 import { Heading } from "~/routes/admin/components/ui/heading";
 import { FadeIn } from "~/routes/common/components/ui/FadeIn";
-import { getProjectById, updateProject } from "~/routes/common/db";
+import { updateProject } from "~/routes/common/db";
 import { deleteStoredImage, handleImageUpload } from "~/utils/upload.server";
 import { validateProjectUpdate } from "../../../../../../database/valibot-validation.js";
 import { Container } from "../../../../common/components/ui/Container";
 import { ProjectFormFields } from "../../../components/ProjectFormFields";
 import { Alert } from "../../../components/ui/alert";
 import { SectionCard, SectionHeading } from "../../../components/ui/section";
+import { fetchAdminProject } from "../services";
 import type { Route } from "./+types/edit";
 
 export async function loader({ params, context, request }: Route.LoaderArgs) {
@@ -17,10 +18,7 @@ export async function loader({ params, context, request }: Route.LoaderArgs) {
 		throw new Response("Invalid Project ID", { status: 400 });
 	}
 	try {
-		const project = await getProjectById(context.db, projectId);
-		if (!project) {
-			throw new Response("Project not found", { status: 404 });
-		}
+		const project = await fetchAdminProject(context.db, projectId);
 		return { project };
 	} catch (error: unknown) {
 		console.error("Error fetching project:", error);

--- a/app/routes/admin/views/projects/index.tsx
+++ b/app/routes/admin/views/projects/index.tsx
@@ -10,7 +10,7 @@ import {
 	useLocation,
 } from "react-router";
 import { ConditionalRichTextRenderer } from "~/routes/common/components/ConditionalRichTextRenderer/index";
-import { deleteProject, getAllProjects } from "~/routes/common/db";
+import { deleteProject } from "~/routes/common/db";
 import { assert } from "~/routes/common/utils/assert";
 import { checkSession } from "~/routes/common/utils/auth";
 import { Container } from "../../../common/components/ui/Container";
@@ -18,6 +18,7 @@ import { PageHeader } from "../../components/ui/PageHeader";
 import { Button } from "../../components/ui/button";
 import { Text } from "../../components/ui/text";
 import type { Route } from "./+types/index";
+import { fetchAdminProjectsList } from "./services";
 
 export async function loader({ request, context }: Route.LoaderArgs) {
 	const env = context.cloudflare?.env;
@@ -25,7 +26,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 		throw redirect("/admin/login");
 	}
 	try {
-		const projects = await getAllProjects(context.db);
+		const projects = await fetchAdminProjectsList(context.db);
 		return { projects };
 	} catch (error: unknown) {
 		console.error("Failed to load projects:", error);

--- a/app/routes/admin/views/projects/services.ts
+++ b/app/routes/admin/views/projects/services.ts
@@ -1,0 +1,33 @@
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import type { Project } from "~/database/schema";
+import { getAllProjects, getProjectById } from "~/routes/common/db";
+import type * as schema from "../../../../database/schema";
+
+export async function fetchAdminProjectsList(
+	db: DrizzleD1Database<typeof schema>,
+): Promise<Project[]> {
+	try {
+		return await getAllProjects(db);
+	} catch (error) {
+		throw new Error(
+			"fetchAdminProjectsList failed: " +
+				(error instanceof Error ? error.message : String(error)),
+		);
+	}
+}
+
+export async function fetchAdminProject(
+	db: DrizzleD1Database<typeof schema>,
+	id: number,
+): Promise<Project> {
+	try {
+		const project = await getProjectById(db, id);
+		if (!project) throw new Error("Project not found");
+		return project;
+	} catch (error) {
+		throw new Error(
+			"fetchAdminProject failed: " +
+				(error instanceof Error ? error.message : String(error)),
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- use service modules in admin loaders
- add admin service functions for content, images, and projects

## Testing
- `bun run format`