### PR TITLE
Add section schemas and generic admin editor

### DIFF
--- a/app/routes/admin/components/AdminDashboard/index.tsx
+++ b/app/routes/admin/components/AdminDashboard/index.tsx
@@ -1,19 +1,12 @@
 import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline";
-import { clsx } from "clsx";
-import React from "react";
-import { Link, useFetcher } from "react-router";
+import type React from "react";
+import { useFetcher } from "react-router";
 import SectionSorter from "~/routes/admin/components/SectionSorter";
-import { AboutSectionEditor } from "~/routes/admin/components/sections/AboutSectionEditor";
-import { ContactSectionEditor } from "~/routes/admin/components/sections/ContactSectionEditor";
-import { HeroSectionEditor } from "~/routes/admin/components/sections/HeroSectionEditor";
-import { ServicesSectionEditor } from "~/routes/admin/components/sections/ServicesSectionEditor";
+import { GenericSectionEditor } from "~/routes/admin/components/sections/GenericSectionEditor";
+import { type SectionId, sectionsSchema } from "~/routes/admin/sections-schema";
 import type { action as adminIndexAction } from "~/routes/admin/views/index";
-import type { action as adminUploadAction } from "~/routes/admin/views/upload";
 import { Container } from "~/routes/common/components/ui/Container";
 import { Button } from "../ui/button";
-import { Input } from "../ui/input";
-import { Strong, Text } from "../ui/text";
-import { Textarea } from "../ui/textarea";
 
 import { type Tab, Tabs } from "~/routes/common/components/ui/Tabs";
 import type {
@@ -21,8 +14,6 @@ import type {
 	SectionTheme as SorterSectionTheme,
 } from "../SectionSorter";
 import { PageHeader } from "../ui/PageHeader";
-import { Heading } from "../ui/heading";
-import { SectionCard, SectionHeading } from "../ui/section";
 
 interface AdminDashboardProps {
 	initialContent?: Record<string, string>;
@@ -32,104 +23,19 @@ export default function AdminDashboard({
 	initialContent,
 }: AdminDashboardProps): React.JSX.Element {
 	const content = initialContent;
-	const heroFetcher = useFetcher<typeof adminIndexAction>();
-	const introFetcher = useFetcher<typeof adminIndexAction>();
-	const servicesFetcher = useFetcher<typeof adminIndexAction>();
-	const aboutFetcher = useFetcher<typeof adminIndexAction>();
-	const contactFetcher = useFetcher<typeof adminIndexAction>();
 	const sorterFetcher = useFetcher<typeof adminIndexAction>();
-	const projectsFetcher = useFetcher<typeof adminIndexAction>();
-	const uploadFetcher = useFetcher<typeof adminUploadAction>();
+	const sectionFetchers: Record<SectionId, ReturnType<typeof useFetcher>> = {
+		hero: useFetcher<typeof adminIndexAction>(),
+		services: useFetcher<typeof adminIndexAction>(),
+		projects: useFetcher<typeof adminIndexAction>(),
+		about: useFetcher<typeof adminIndexAction>(),
+		contact: useFetcher<typeof adminIndexAction>(),
+	};
 	const safeContent =
 		content && typeof content === "object" && !("error" in content)
 			? (content as Record<string, string>)
 			: ({} as Record<string, string>);
-	const [heroUploading, setHeroUploading] = React.useState(false);
-	const [heroImageUrl, setHeroImageUrl] = React.useState(
-		safeContent.hero_image_url || "",
-	);
-	const [aboutUploading, setAboutUploading] = React.useState(false);
-	const [aboutImageUrl, setAboutImageUrl] = React.useState(
-		safeContent.about_image_url || "",
-	);
-	const [serviceUploading, setServiceUploading] = React.useState<boolean[]>(
-		Array(4).fill(false),
-	);
-	const [serviceImageUrls, setServiceImageUrls] = React.useState([
-		safeContent.service_1_image || "",
-		safeContent.service_2_image || "",
-		safeContent.service_3_image || "",
-		safeContent.service_4_image || "",
-	]);
 
-	React.useEffect(() => {
-		if (
-			uploadFetcher.state === "idle" &&
-			uploadFetcher.data &&
-			typeof uploadFetcher.data === "object" &&
-			"key" in uploadFetcher.data
-		) {
-			const data = uploadFetcher.data as {
-				success?: boolean;
-				url?: string;
-				key?: string;
-			};
-			const key = data.key || "";
-			const url = data.url || "";
-			const match = key.match(/^service_(\d+)_image$/);
-
-			if (key === "hero_image_url") {
-				if (data.success && url) setHeroImageUrl(url);
-				setHeroUploading(false);
-			} else if (key === "about_image_url") {
-				if (data.success && url) setAboutImageUrl(url);
-				setAboutUploading(false);
-			} else if (match) {
-				const idx = Number(match[1]) - 1;
-				if (idx >= 0) {
-					if (data.success && url) {
-						setServiceImageUrls((prev) =>
-							prev.map((val, i) => (i === idx ? url : val)),
-						);
-					}
-					setServiceUploading((prev) =>
-						prev.map((val, i) => (i === idx ? false : val)),
-					);
-				}
-			}
-		}
-	}, [uploadFetcher.state, uploadFetcher.data]);
-	const uploadImage = React.useCallback(
-		(
-			fetcherInstance: ReturnType<
-				typeof useFetcher<typeof adminUploadAction | typeof adminIndexAction>
-			>,
-			key: string,
-			file: File,
-			setUploading: (v: boolean) => void,
-		) => {
-			setUploading(true);
-			const fd = new FormData();
-			fd.append("image", file);
-			fd.append("key", key);
-			fetcherInstance.submit(fd, {
-				method: "post",
-				action: "/admin/upload",
-				encType: "multipart/form-data",
-			});
-		},
-		[],
-	);
-	const handleHeroImageUpload = (file: File) =>
-		uploadImage(uploadFetcher, "hero_image_url", file, setHeroUploading);
-	const handleAboutImageUpload = (file: File) =>
-		uploadImage(uploadFetcher, "about_image_url", file, setAboutUploading);
-	const handleServiceImageUpload = (idx: number, file: File) =>
-		uploadImage(uploadFetcher, `service_${idx + 1}_image`, file, (v) =>
-			setServiceUploading((prev) =>
-				prev.map((val, i) => (i === idx ? v : val)),
-			),
-		);
 	const sectionsOrder = safeContent.home_sections_order as string | undefined;
 	const orderedSectionIds: SectionId[] = sectionsOrder
 		? (sectionsOrder.split(",") as SectionId[])
@@ -157,86 +63,27 @@ export default function AdminDashboard({
 					initialSectionsFromDb={sorterSections}
 					sectionDetailsOrdered={sorterSections}
 					orderFetcher={sorterFetcher}
-					themeUpdateFetcher={heroFetcher}
+					themeUpdateFetcher={sectionFetchers.hero}
 				/>
 			),
 		},
 	];
 
 	for (const id of orderedSectionIds) {
-		switch (id) {
-			case "hero":
-				tabs.push({
-					title: sectionsSchema.hero.label,
-					value: "hero",
-					content: (
-						<HeroSectionEditor
-							fetcher={heroFetcher}
-							initialContent={safeContent}
-							onImageUpload={handleHeroImageUpload}
-							imageUploading={heroUploading}
-							heroImageUrl={heroImageUrl}
-						/>
-					),
-				});
-				break;
-			case "services":
-				tabs.push({
-					title: sectionsSchema.services.label,
-					value: "services",
-					content: (
-						<ServicesSectionEditor
-							fetcher={servicesFetcher}
-							initialContent={safeContent}
-							onImageUpload={handleServiceImageUpload}
-							imageUploading={serviceUploading}
-							serviceImageUrls={serviceImageUrls}
-						/>
-					),
-				});
-				break;
-			case "projects":
-				tabs.push({
-					title: sectionsSchema.projects.label,
-					value: "projects",
-					content: (
-						<ProjectsSectionEditor
-							fetcher={projectsFetcher}
-							initialContent={safeContent}
-						/>
-					),
-				});
-				break;
-			case "about":
-				tabs.push({
-					title: sectionsSchema.about.label,
-					value: "about",
-					content: (
-						<AboutSectionEditor
-							fetcher={aboutFetcher}
-							initialContent={safeContent}
-							onImageUpload={handleAboutImageUpload}
-							imageUploading={aboutUploading}
-							aboutImageUrl={aboutImageUrl}
-						/>
-					),
-				});
-				break;
-			case "contact":
-				tabs.push({
-					title: sectionsSchema.contact.label,
-					value: "contact",
-					content: (
-						<ContactSectionEditor
-							fetcher={contactFetcher}
-							initialContent={safeContent}
-						/>
-					),
-				});
-				break;
-			default:
-				break;
-		}
+		const details = sectionsSchema[id];
+		if (!details) continue;
+		const fetcher = sectionFetchers[id];
+		tabs.push({
+			title: details.label,
+			value: id,
+			content: (
+				<GenericSectionEditor
+					schema={details}
+					fetcher={fetcher}
+					initialContent={safeContent}
+				/>
+			),
+		});
 	}
 	return (
 		<Container className="mt-8">

--- a/app/routes/admin/components/sections/GenericSectionEditor.tsx
+++ b/app/routes/admin/components/sections/GenericSectionEditor.tsx
@@ -1,0 +1,107 @@
+import type React from "react";
+import type { useFetcher } from "react-router";
+import type { ContentInputType, SectionSchema } from "~/section-schema";
+import { Alert } from "../ui/alert";
+import { Input } from "../ui/input";
+import { FieldLabel, SectionCard, SectionHeading } from "../ui/section";
+import { Text } from "../ui/text";
+import { Textarea } from "../ui/textarea";
+
+interface GenericSectionEditorProps {
+	schema: SectionSchema;
+	fetcher: ReturnType<typeof useFetcher>;
+	initialContent: Record<string, string>;
+}
+
+export function GenericSectionEditor({
+	schema,
+	fetcher,
+	initialContent,
+}: GenericSectionEditorProps) {
+	const actionData = fetcher.data as
+		| { error?: string; errors?: Record<string, string> }
+		| undefined;
+
+	const handleBlur = (
+		e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>,
+	) => {
+		const { name, value } = e.currentTarget;
+		const formData = new FormData();
+		formData.append("intent", "updateTextContent");
+		formData.append(name, value);
+		fetcher.submit(formData, { method: "post", action: "/admin" });
+	};
+
+	const renderField = (
+		key: string,
+		field: { label: string; inputType: ContentInputType },
+	) => {
+		const id = key;
+		const defaultValue = initialContent[key] || "";
+		const error = actionData?.errors?.[key];
+		switch (field.inputType) {
+			case "richtext":
+				return (
+					<div key={key} className="flex flex-col gap-1 min-w-0">
+						<FieldLabel htmlFor={id}>{field.label}</FieldLabel>
+						<Textarea
+							id={id}
+							name={id}
+							defaultValue={defaultValue}
+							onBlur={handleBlur}
+							rows={4}
+						/>
+						{error && (
+							<Text className="text-sm text-red-600 mt-1">{error}</Text>
+						)}
+					</div>
+				);
+			case "image":
+				return (
+					<div key={key} className="flex flex-col gap-1 min-w-0">
+						<FieldLabel>{field.label}</FieldLabel>
+						<Input
+							type="text"
+							name={id}
+							defaultValue={defaultValue}
+							onBlur={handleBlur}
+						/>
+						{error && (
+							<Text className="text-sm text-red-600 mt-1">{error}</Text>
+						)}
+					</div>
+				);
+			default:
+				return (
+					<div key={key} className="flex flex-col gap-1 min-w-0">
+						<FieldLabel htmlFor={id}>{field.label}</FieldLabel>
+						<Input
+							id={id}
+							name={id}
+							defaultValue={defaultValue}
+							onBlur={handleBlur}
+						/>
+						{error && (
+							<Text className="text-sm text-red-600 mt-1">{error}</Text>
+						)}
+					</div>
+				);
+		}
+	};
+
+	return (
+		<SectionCard>
+			{actionData?.error && (
+				<Alert variant="error" title="Save failed" className="mb-4">
+					{actionData.error}
+				</Alert>
+			)}
+			<SectionHeading>{schema.label} Section</SectionHeading>
+			<div className="grid grid-cols-1 md:grid-cols-2 gap-y-6 gap-x-3 sm:gap-x-6">
+				{Object.entries(schema.fields).map(([key, field]) =>
+					renderField(key, field),
+				)}
+			</div>
+		</SectionCard>
+	);
+}

--- a/app/routes/admin/sections-schema.ts
+++ b/app/routes/admin/sections-schema.ts
@@ -1,14 +1,16 @@
-export interface SectionSchema {
-	label: string;
-	themeKey: string;
-}
+import type { SectionSchema } from "~/section-schema";
+import { projectsSectionSchema } from "../common/components/RecentProjects/schema";
+import { aboutSectionSchema } from "../home/components/AboutUs/schema";
+import { contactSectionSchema } from "../home/components/ContactUs/schema";
+import { heroSectionSchema } from "../home/components/Hero/schema";
+import { servicesSectionSchema } from "../home/components/OurServices/schema";
 
 export const sectionsSchema: Record<string, SectionSchema> = {
-	hero: { label: "Hero", themeKey: "hero_title_theme" },
-	services: { label: "Services", themeKey: "services_intro_title_theme" },
-	projects: { label: "Projects", themeKey: "projects_intro_title_theme" },
-	about: { label: "About", themeKey: "about_title_theme" },
-	contact: { label: "Contact", themeKey: "contact_title_theme" },
+	hero: heroSectionSchema,
+	services: servicesSectionSchema,
+	projects: projectsSectionSchema,
+	about: aboutSectionSchema,
+	contact: contactSectionSchema,
 };
 
 export type SectionId = keyof typeof sectionsSchema;

--- a/app/routes/common/components/RecentProjects/schema.ts
+++ b/app/routes/common/components/RecentProjects/schema.ts
@@ -1,0 +1,11 @@
+import type { SectionSchema } from "~/section-schema";
+
+export const projectsSectionSchema: SectionSchema = {
+	id: "projects",
+	label: "Projects",
+	themeKey: "projects_intro_title_theme",
+	fields: {
+		projects_intro_title: { label: "Intro Title", inputType: "text" },
+		projects_intro_text: { label: "Intro Text", inputType: "richtext" },
+	},
+};

--- a/app/routes/home/components/AboutUs/schema.ts
+++ b/app/routes/home/components/AboutUs/schema.ts
@@ -1,0 +1,12 @@
+import type { SectionSchema } from "~/section-schema";
+
+export const aboutSectionSchema: SectionSchema = {
+	id: "about",
+	label: "About",
+	themeKey: "about_title_theme",
+	fields: {
+		about_title: { label: "About Title", inputType: "text" },
+		about_text: { label: "About Text", inputType: "richtext" },
+		about_image_url: { label: "About Image", inputType: "image" },
+	},
+};

--- a/app/routes/home/components/ContactUs/schema.ts
+++ b/app/routes/home/components/ContactUs/schema.ts
@@ -1,0 +1,19 @@
+import type { SectionSchema } from "~/section-schema";
+
+export const contactSectionSchema: SectionSchema = {
+	id: "contact",
+	label: "Contact",
+	themeKey: "contact_title_theme",
+	fields: {
+		contact_headline: { label: "Headline", inputType: "text" },
+		contact_intro: { label: "Intro Text", inputType: "richtext" },
+		contact_address: { label: "Address", inputType: "text" },
+		contact_phone: { label: "Phone", inputType: "text" },
+		contact_email: { label: "Email", inputType: "text" },
+		contact_hours: { label: "Hours", inputType: "text" },
+		contact_abn: { label: "ABN", inputType: "text" },
+		contact_acn: { label: "ACN", inputType: "text" },
+		contact_license: { label: "License", inputType: "text" },
+		contact_instagram: { label: "Instagram", inputType: "text" },
+	},
+};

--- a/app/routes/home/components/Hero/schema.ts
+++ b/app/routes/home/components/Hero/schema.ts
@@ -1,0 +1,12 @@
+import type { SectionSchema } from "~/section-schema";
+
+export const heroSectionSchema: SectionSchema = {
+	id: "hero",
+	label: "Hero",
+	themeKey: "hero_title_theme",
+	fields: {
+		hero_title: { label: "Hero Title", inputType: "text" },
+		hero_subtitle: { label: "Hero Subtitle", inputType: "richtext" },
+		hero_image_url: { label: "Hero Image", inputType: "image" },
+	},
+};

--- a/app/routes/home/components/OurServices/schema.ts
+++ b/app/routes/home/components/OurServices/schema.ts
@@ -1,0 +1,19 @@
+import type { SectionSchema } from "~/section-schema";
+
+export const servicesSectionSchema: SectionSchema = {
+	id: "services",
+	label: "Services",
+	themeKey: "services_intro_title_theme",
+	fields: {
+		services_intro_title: { label: "Intro Title", inputType: "text" },
+		services_intro_text: { label: "Intro Text", inputType: "richtext" },
+		service_1_title: { label: "Service 1 Title", inputType: "text" },
+		service_1_image: { label: "Service 1 Image", inputType: "image" },
+		service_2_title: { label: "Service 2 Title", inputType: "text" },
+		service_2_image: { label: "Service 2 Image", inputType: "image" },
+		service_3_title: { label: "Service 3 Title", inputType: "text" },
+		service_3_image: { label: "Service 3 Image", inputType: "image" },
+		service_4_title: { label: "Service 4 Title", inputType: "text" },
+		service_4_image: { label: "Service 4 Image", inputType: "image" },
+	},
+};

--- a/app/section-schema.ts
+++ b/app/section-schema.ts
@@ -1,0 +1,13 @@
+export type ContentInputType = "text" | "richtext" | "image";
+
+export interface ContentFieldSchema {
+	label: string;
+	inputType: ContentInputType;
+}
+
+export interface SectionSchema {
+	id: string;
+	label: string;
+	themeKey: string;
+	fields: Record<string, ContentFieldSchema>;
+}


### PR DESCRIPTION
## Summary
- define generic section schema types
- export schemas from public section components
- aggregate section schemas in admin
- introduce `GenericSectionEditor` for admin forms
- update `AdminDashboard` to use new schemas

## Testing
- `bun run format`