### PR TITLE
Implement CmsClient abstraction

### DIFF
--- a/app/routes/admin/actions/seed-content.tsx
+++ b/app/routes/admin/actions/seed-content.tsx
@@ -1,5 +1,4 @@
 import { data } from "react-router";
-import { getAllContent, updateContent } from "~/database/contentRepo";
 import { checkSession } from "~/utils/auth";
 import type { Route } from "./+types/seed-content";
 
@@ -19,7 +18,7 @@ export async function action({ request, context, params }: Route.ActionArgs) {
 		return data({ error: "Invalid method. Please use POST." }, { status: 405 });
 	}
 	try {
-		const existingContent = await getAllContent(context.db);
+		const existingContent = await context.cms.getAllContent();
 		const missingKeys = Object.keys(DEFAULT_CONTENT).filter(
 			(key) => !existingContent[key],
 		);
@@ -36,7 +35,7 @@ export async function action({ request, context, params }: Route.ActionArgs) {
 			},
 			{} as Record<string, string>,
 		);
-		await updateContent(context.db, updatesToSeed);
+		await context.cms.updateContent(updatesToSeed);
 		return data({
 			success: true,
 			message: `Successfully seeded ${missingKeys.length} missing content items.`,

--- a/app/routes/admin/index.tsx
+++ b/app/routes/admin/index.tsx
@@ -3,7 +3,6 @@ import { useActionData, useNavigation, useSearchParams } from "react-router";
 import { redirect } from "react-router";
 import { Toaster, toast } from "sonner";
 import { ValiError } from "valibot";
-import { updateContent } from "~/database/contentRepo";
 import { assert } from "~/utils/assert";
 import { checkSession } from "~/utils/auth";
 import { validateContentInsert } from "../../../../database/valibot-validation.js";
@@ -21,7 +20,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 	}
 
 	try {
-		const content = await fetchAdminContent(context.db);
+		const content = await fetchAdminContent(context.cms);
 		if (DEBUG)
 			console.log("[ADMIN LOADER] Loaded content keys:", Object.keys(content));
 		return { content };
@@ -69,7 +68,7 @@ async function handleUpdateTextContent(
 		return { success: false, errors: validationErrors };
 	}
 
-	await updateContent(context.db, updates);
+	await context.cms.updateContent(updates);
 	return { success: true, action: "updateTextContent" };
 }
 
@@ -80,7 +79,7 @@ async function handleReorderSections(
 	const order = formData.get("home_sections_order")?.toString();
 	if (!order) return { success: false, error: "Missing sections order" };
 
-	await updateContent(context.db, { home_sections_order: order });
+	await context.cms.updateContent({ home_sections_order: order });
 	return { success: true, action: "reorderSections" };
 }
 

--- a/app/routes/admin/projects/[projectId]/delete.tsx
+++ b/app/routes/admin/projects/[projectId]/delete.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Form, redirect, useNavigate } from "react-router";
-import { deleteProject } from "~/database/projectRepo";
 import {
 	Alert,
 	AlertDescription,
@@ -23,7 +22,7 @@ export async function loader({ params, context, request }: Route.LoaderArgs) {
 		throw new Response("Invalid Project ID", { status: 400 });
 	}
 	try {
-		const project = await fetchAdminProject(context.db, projectId);
+		const project = await fetchAdminProject(context.cms, projectId);
 		return { project };
 	} catch (error: unknown) {
 		console.error("Error fetching project:", error);
@@ -44,7 +43,7 @@ export async function action({ request, params, context }: Route.ActionArgs) {
 		return { success: false, error: "Deletion was not confirmed" };
 	}
 	try {
-		await deleteProject(context.db, projectId);
+		await context.cms.deleteProject(projectId);
 		return redirect("/admin/projects");
 	} catch (error: unknown) {
 		console.error("Error deleting project:", error);

--- a/app/routes/admin/projects/[projectId]/edit.tsx
+++ b/app/routes/admin/projects/[projectId]/edit.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { redirect } from "react-router";
-import { updateProject } from "~/database/projectRepo";
 import { Heading } from "~/routes/admin/components/ui/heading";
 import { FadeIn } from "~/routes/common/components/ui/FadeIn";
 import { deleteStoredImage, handleImageUpload } from "~/utils/upload.server";
@@ -18,7 +17,7 @@ export async function loader({ params, context, request }: Route.LoaderArgs) {
 		throw new Response("Invalid Project ID", { status: 400 });
 	}
 	try {
-		const project = await fetchAdminProject(context.db, projectId);
+		const project = await fetchAdminProject(context.cms, projectId);
 		return { project };
 	} catch (error: unknown) {
 		console.error("Error fetching project:", error);
@@ -90,7 +89,7 @@ export async function action({ request, params, context }: Route.ActionArgs) {
 			sortOrder,
 		};
 		validateProjectUpdate(projectData);
-		const updated = await updateProject(context.db, projectId, projectData);
+		const updated = await context.cms.updateProject(projectId, projectData);
 		if (!updated) {
 			// rollback uploaded file if DB update failed
 			if (uploadedKey) {

--- a/app/routes/admin/projects/index.tsx
+++ b/app/routes/admin/projects/index.tsx
@@ -9,7 +9,6 @@ import {
 	useActionData,
 	useLocation,
 } from "react-router";
-import { deleteProject } from "~/database/projectRepo";
 import { ConditionalRichTextRenderer } from "~/routes/common/components/ConditionalRichTextRenderer/index";
 import { assert } from "~/utils/assert";
 import { checkSession } from "~/utils/auth";
@@ -26,7 +25,7 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 		throw redirect("/admin/login");
 	}
 	try {
-		const projects = await fetchAdminProjectsList(context.db);
+		const projects = await fetchAdminProjectsList(context.cms);
 		return { projects };
 	} catch (error: unknown) {
 		console.error("Failed to load projects:", error);
@@ -59,7 +58,7 @@ export async function action({ request, context }: Route.ActionArgs) {
 			);
 		}
 		try {
-			await deleteProject(context.db, projectId);
+			await context.cms.deleteProject(projectId);
 			return data({ success: true, projectId });
 		} catch (error: unknown) {
 			console.error("Failed to delete project:", error);

--- a/app/routes/admin/projects/new.tsx
+++ b/app/routes/admin/projects/new.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { redirect, useNavigate } from "react-router";
-import { createProject } from "~/database/projectRepo";
 import { FadeIn } from "~/routes/common/components/ui/FadeIn";
 import { assert } from "~/utils/assert";
 import type { NewProject } from "../../../../../database/schema";
@@ -33,8 +32,7 @@ export async function action({ request, context, params }: Route.ActionArgs) {
 	};
 	try {
 		validateProjectInsert(projectData);
-		await createProject(
-			context.db,
+		await context.cms.createProject(
 			projectData as Omit<NewProject, "id" | "createdAt" | "updatedAt">,
 		);
 		return redirect("/admin/projects");

--- a/app/routes/admin/projects/services.ts
+++ b/app/routes/admin/projects/services.ts
@@ -1,13 +1,11 @@
-import type { DrizzleD1Database } from "drizzle-orm/d1";
-import { getAllProjects, getProjectById } from "~/database/projectRepo";
 import type { Project } from "~/database/schema";
-import type * as schema from "../../../../database/schema";
+import type { CmsClient } from "~/services/cms.client";
 
 export async function fetchAdminProjectsList(
-	db: DrizzleD1Database<typeof schema>,
+	cms: CmsClient,
 ): Promise<Project[]> {
 	try {
-		return await getAllProjects(db);
+		return await cms.getAllProjects();
 	} catch (error) {
 		throw new Error(
 			`fetchAdminProjectsList failed: ${
@@ -18,11 +16,11 @@ export async function fetchAdminProjectsList(
 }
 
 export async function fetchAdminProject(
-	db: DrizzleD1Database<typeof schema>,
+	cms: CmsClient,
 	id: number,
 ): Promise<Project> {
 	try {
-		const project = await getProjectById(db, id);
+		const project = await cms.getProjectById(id);
 		if (!project) throw new Error("Project not found");
 		return project;
 	} catch (error) {

--- a/app/routes/admin/services.ts
+++ b/app/routes/admin/services.ts
@@ -1,14 +1,12 @@
-import type { DrizzleD1Database } from "drizzle-orm/d1";
 import type { AppLoadContext } from "react-router";
-import { getAllContent } from "~/database/contentRepo";
+import type { CmsClient } from "~/services/cms.client";
 import { listStoredImages } from "~/utils/upload.server";
-import type * as schema from "../../database/schema";
 
 export async function fetchAdminContent(
-	db: DrizzleD1Database<typeof schema>,
+	cms: CmsClient,
 ): Promise<Record<string, string>> {
 	try {
-		return await getAllContent(db);
+		return await cms.getAllContent();
 	} catch (error) {
 		throw new Error(
 			`fetchAdminContent failed: ${

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -34,14 +34,14 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 		`[HOME LOADER START] Invoked at: ${new Date().toISOString()}, URL: ${request.url}`,
 	);
 	assert(request instanceof Request, "loader: request must be a Request");
-	assert(context?.db, "loader: missing DB in context");
+	assert(context?.cms, "loader: missing CMS client in context");
 	const url = new URL(request.url);
 	const revalidate = url.searchParams.get("revalidate") === "true";
 	if (DEBUG) console.log("[HOME LOADER] Revalidation requested:", revalidate);
 	let content: Record<string, string> = {};
 	let projects: Project[] = [];
 	try {
-		({ content, projects } = await loadHomeData(context.db));
+		({ content, projects } = await loadHomeData(context.cms));
 		if (DEBUG) {
 			console.log("[HOME LOADER] Content keys loaded:", Object.keys(content));
 			console.log("[HOME LOADER] Project count:", projects.length);

--- a/app/routes/home/services.ts
+++ b/app/routes/home/services.ts
@@ -1,16 +1,13 @@
-import type { DrizzleD1Database } from "drizzle-orm/d1";
-import { getAllContent } from "~/database/contentRepo";
-import { getFeaturedProjects } from "~/database/projectRepo";
 import type { Project } from "~/database/schema";
-import type * as schema from "~/database/schema";
+import type { CmsClient } from "~/services/cms.client";
 import type { ServiceItem } from "./components/OurServices";
 
 export async function loadHomeData(
-	db: DrizzleD1Database<typeof schema>,
+	cms: CmsClient,
 ): Promise<{ content: Record<string, string>; projects: Project[] }> {
 	try {
-		const content = await getAllContent(db);
-		const projects = await getFeaturedProjects(db);
+		const content = await cms.getAllContent();
+		const projects = await cms.getFeaturedProjects();
 		return { content, projects };
 	} catch (error) {
 		throw new Error(

--- a/app/routes/projects.tsx
+++ b/app/routes/projects.tsx
@@ -19,7 +19,7 @@ export const loader = async ({
 	params,
 }: Route.LoaderArgs) => {
 	try {
-		const { content, projects } = await fetchProjectsList(context.db);
+		const { content, projects } = await fetchProjectsList(context.cms);
 		if (!projects || projects.length === 0) {
 			return redirect("/");
 		}

--- a/app/routes/projects/[projectId].tsx
+++ b/app/routes/projects/[projectId].tsx
@@ -20,7 +20,7 @@ export const loader = async ({
 	const projectId = Number(params.projectId);
 	assert(!Number.isNaN(projectId), "projectId must be a valid number");
 	try {
-		const project = await fetchProjectDetails(context.db, projectId);
+		const project = await fetchProjectDetails(context.cms, projectId);
 		assert(
 			project && typeof project === "object" && project.id != null,
 			"loader must return a project",

--- a/app/routes/projects/layout.tsx
+++ b/app/routes/projects/layout.tsx
@@ -18,7 +18,7 @@ export const loader = async ({
 	params,
 }: Route.LoaderArgs) => {
 	try {
-		const { content, projects } = await fetchProjectsList(context.db);
+		const { content, projects } = await fetchProjectsList(context.cms);
 		return { content, projects };
 	} catch (error: unknown) {
 		console.error("Failed to fetch content or projects:", error);

--- a/app/routes/projects/services.ts
+++ b/app/routes/projects/services.ts
@@ -1,15 +1,12 @@
-import type { DrizzleD1Database } from "drizzle-orm/d1";
-import { getAllContent } from "~/database/contentRepo";
-import { getAllProjects, getProjectById } from "~/database/projectRepo";
 import type { Project } from "~/database/schema";
-import type * as schema from "~/database/schema";
+import type { CmsClient } from "~/services/cms.client";
 
 export async function fetchProjectsList(
-	db: DrizzleD1Database<typeof schema>,
+	cms: CmsClient,
 ): Promise<{ content: Record<string, string>; projects: Project[] }> {
 	try {
-		const content = await getAllContent(db);
-		const projects = await getAllProjects(db);
+		const content = await cms.getAllContent();
+		const projects = await cms.getAllProjects();
 		return { content, projects };
 	} catch (error) {
 		throw new Error(
@@ -21,11 +18,11 @@ export async function fetchProjectsList(
 }
 
 export async function fetchProjectDetails(
-	db: DrizzleD1Database<typeof schema>,
+	cms: CmsClient,
 	id: number,
 ): Promise<Project> {
 	try {
-		const project = await getProjectById(db, id);
+		const project = await cms.getProjectById(id);
 		if (!project) throw new Error("Project not found");
 		return project;
 	} catch (error) {

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -11,7 +11,7 @@ Here's an actionable, enumerated task list derived from the analysis of the repo
 - [x] **6.** Split `app/routes/common/db/index.ts` into separate modules per domain (e.g., `database/contentRepo.ts`, `database/projectRepo.ts`).
 
 ## ✅ **CMS Integration & Flexibility**
-- [ ] **7.** Abstract the CMS/data layer by creating a `CmsProvider` or `cms.client.ts` with methods for all data interactions..
+- [x] **7.** Abstract the CMS/data layer by creating a `CmsProvider` or `cms.client.ts` with methods for all data interactions..
 - [ ] **9.** Decouple content schema definitions from rendering logic, moving schemas/configurations into centralized modules.
 - [ ] **10.** Provide clear, documented guidance on integrating external CMS providers (e.g., Contentful or Sanity).
 

--- a/load-context.ts
+++ b/load-context.ts
@@ -3,6 +3,7 @@ import { type DrizzleD1Database, drizzle } from "drizzle-orm/d1";
 import { DefaultLogger } from "drizzle-orm/logger";
 import type { AppLoadContext } from "react-router";
 import * as schema from "./database/schema";
+import { CmsClient } from "~/services/cms.client";
 declare global {
 	interface CloudflareEnvironment extends Env {
 		ADMIN_USERNAME: string;
@@ -14,29 +15,32 @@ declare global {
         }
 }
 declare module "react-router" {
-	export interface AppLoadContext {
-		cloudflare: {
-			env: CloudflareEnvironment;
-			ctx: Omit<ExecutionContext, "props">;
-		};
-		db: DrizzleD1Database<typeof schema>;
-	}
+        export interface AppLoadContext {
+                cloudflare: {
+                        env: CloudflareEnvironment;
+                        ctx: Omit<ExecutionContext, "props">;
+                };
+                db: DrizzleD1Database<typeof schema>;
+                cms: CmsClient;
+        }
 }
 type GetLoadContextArgs = {
 	request: Request;
 	context: Pick<AppLoadContext, "cloudflare">;
 };
 export function getLoadContext({ context }: GetLoadContextArgs) {
-	const db = drizzle(context.cloudflare.env.DB, {
-		schema,
-		// Enable logger only in development mode
-		logger:
-			import.meta.env.MODE === "development" // Vite standard for mode
-				? new DefaultLogger()
-				: false,
-	});
-	return {
-		cloudflare: context.cloudflare,
-		db,
-	};
+        const db = drizzle(context.cloudflare.env.DB, {
+                schema,
+                // Enable logger only in development mode
+                logger:
+                        import.meta.env.MODE === "development" // Vite standard for mode
+                                ? new DefaultLogger()
+                                : false,
+        });
+        const cms = new CmsClient(db);
+        return {
+                cloudflare: context.cloudflare,
+                db,
+                cms,
+        };
 }

--- a/services/cms.client.ts
+++ b/services/cms.client.ts
@@ -1,0 +1,66 @@
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import * as schema from "~/database/schema";
+import type { NewContent, NewProject, Project } from "~/database/schema";
+import {
+    getAllContent,
+    updateContent,
+} from "~/database/contentRepo";
+import {
+    getAllProjects,
+    getFeaturedProjects,
+    getProjectById,
+    createProject,
+    updateProject,
+    deleteProject,
+} from "~/database/projectRepo";
+
+export class CmsClient {
+    constructor(private readonly db: DrizzleD1Database<typeof schema>) {}
+
+    async getAllContent() {
+        return getAllContent(this.db);
+    }
+
+    async updateContent(
+        updates: Record<
+            string,
+            | string
+            | number
+            | boolean
+            | Record<string, unknown>
+            | Array<unknown>
+            | (Partial<Omit<NewContent, "key">> & { value: unknown })
+        >,
+    ) {
+        return updateContent(this.db, updates);
+    }
+
+    async getAllProjects(): Promise<Project[]> {
+        return getAllProjects(this.db);
+    }
+
+    async getFeaturedProjects(): Promise<Project[]> {
+        return getFeaturedProjects(this.db);
+    }
+
+    async getProjectById(id: number): Promise<Project | undefined> {
+        return getProjectById(this.db, id);
+    }
+
+    async createProject(
+        projectData: Omit<NewProject, "id" | "createdAt" | "updatedAt">,
+    ): Promise<Project> {
+        return createProject(this.db, projectData);
+    }
+
+    async updateProject(
+        id: number,
+        projectData: Partial<Omit<NewProject, "id" | "createdAt">>,
+    ): Promise<Project | undefined> {
+        return updateProject(this.db, id, projectData);
+    }
+
+    async deleteProject(id: number) {
+        return deleteProject(this.db, id);
+    }
+}


### PR DESCRIPTION
## Summary
- add `CmsClient` to encapsulate data operations
- expose CMS client via `getLoadContext`
- refactor routes to use the new client
- mark CMS provider task as complete

## Testing
- `bun run format`