### PR TITLE
Add JSDoc comments for Durable Objects and loader

### DIFF
--- a/app/routes/projects/layout.tsx
+++ b/app/routes/projects/layout.tsx
@@ -12,6 +12,10 @@ type ProjectsLayoutLoaderData = {
 	projects: Project[];
 	error?: string;
 };
+/**
+ * Loader for the Projects layout. Retrieves page content and a list of
+ * projects from the CMS. Any errors are surfaced as 500 responses.
+ */
 export const loader = async ({
 	context,
 	request,

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -18,7 +18,7 @@ Here's an actionable, enumerated task list derived from the analysis of the repo
 - [x] **11.** Enhance README documentation with explicit setup instructions (e.g., installing Bun, Wrangler, Cloudflare credentials setup).
  - [x] **13.** Integrate formatting and linting tools (Biome) with pre-commit hooks using Husky.
 - [x] **14.** Clearly document testing instructions and include additional example unit tests for loaders and utilities.
-- [ ] **15.** Add inline code documentation (JSDoc-style) to clarify roles of complex components (e.g., Durable Objects, loaders).
+- [x] **15.** Add inline code documentation (JSDoc-style) to clarify roles of complex components (e.g., Durable Objects, loaders).
 - [ ] **16.** Enforce a secure default admin password setup with prompts or warnings in the admin interface or console logs.
 
 ## ✅ **Scalability & Maintainability**

--- a/workers/drizzle-durable.ts
+++ b/workers/drizzle-durable.ts
@@ -1,9 +1,17 @@
 import { type DrizzleD1Database, drizzle } from "drizzle-orm/d1";
 import { DefaultLogger } from "drizzle-orm/logger";
 import { createRequestHandler } from "react-router";
-import type { DurableObjectState, ExecutionContext } from "@cloudflare/workers-types";
+import type {
+  DurableObjectState,
+  ExecutionContext,
+} from "@cloudflare/workers-types";
 import * as schema from "../database/schema";
 
+/**
+ * Durable Object exposing the Drizzle ORM database.
+ * Incoming requests are forwarded to React Router with the database
+ * instance attached to the load context for server-side routing.
+ */
 const serverBuildModuleResolver = () => import("virtual:react-router/server-build");
 const requestHandler = createRequestHandler(serverBuildModuleResolver, import.meta.env.MODE);
 
@@ -16,6 +24,10 @@ export class DrizzleDurable implements DurableObject {
     });
   }
 
+  /**
+   * Handles HTTP requests by forwarding them to React Router. The database
+   * and environment are provided via the load context for loader functions.
+   */
   async fetch(request: Request) {
     const loadContext = {
       cloudflare: { env: this.env, ctx: {} as Omit<ExecutionContext, "props"> },

--- a/workers/session-durable.ts
+++ b/workers/session-durable.ts
@@ -7,9 +7,18 @@ interface SessionRecord {
 
 const SESSION_TTL = 60 * 60 * 2; // 2 hours
 
+/**
+ * Durable Object providing a simple key/value session store.
+ * Each session record is persisted with a TTL to automatically
+ * clean up expired sessions.
+ */
 export class SessionDurable implements DurableObject {
   constructor(private state: DurableObjectState, private env: Env) {}
 
+  /**
+   * CRUD-style handler for session data keyed by the request path.
+   * Supports PUT to create, GET to read, and DELETE to remove a session.
+   */
   async fetch(request: Request): Promise<Response> {
     const id = new URL(request.url).pathname.slice(1);
     if (!id) return new Response("Bad Request", { status: 400 });


### PR DESCRIPTION
## Summary
- document database Durable Object and session Durable Object
- document Projects layout loader
- mark JSDoc task as complete in docs

## Testing
- `bun run format`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (JSDoc/comments and a tasks checklist update) with no functional behavior changes, so risk is low.
> 
> **Overview**
> Adds **inline JSDoc documentation** to the `ProjectsLayout` `loader` and both Durable Objects (`DrizzleDurable` and `SessionDurable`) to clarify their responsibilities and request/loader context behavior.
> 
> Updates `docs/TASKS.md` to mark the “add inline code documentation” task as completed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0343846a64d4739bf8bf07b0d249131c2c4f19f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->